### PR TITLE
fix: deployment pipeline failing

### DIFF
--- a/.github/workflows/deploy_asciidoc.yml
+++ b/.github/workflows/deploy_asciidoc.yml
@@ -69,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.BOT_SSH_KEY }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
The deployment pipeline was failing on main because of the branch protection. Adding a deploy key as the committer will bypass this restriction.